### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AleksandrDudkin/e6111b5a-df83-403c-b79e-711290cd48fc/272fdaeb-e944-429c-b4be-6f05c56d2b5c/_apis/work/boardbadge/865b65ef-63d6-43e0-bbb4-e25fa0dd83c0)](https://dev.azure.com/AleksandrDudkin/e6111b5a-df83-403c-b79e-711290cd48fc/_boards/board/t/272fdaeb-e944-429c-b4be-6f05c56d2b5c/Microsoft.RequirementCategory)
 ---
 page_type: sample
 name: "HTML sample for Azure App Service"


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#147](https://dev.azure.com/AleksandrDudkin/e6111b5a-df83-403c-b79e-711290cd48fc/_workitems/edit/147). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.